### PR TITLE
Add support for gzip wrapper

### DIFF
--- a/include/gzip_cpp.h
+++ b/include/gzip_cpp.h
@@ -38,7 +38,7 @@ class Comp {
    };
  public:
   /// Construct a compressor.
-  explicit Comp(Level level = Level::Default);
+  explicit Comp(Level level = Level::Default, bool gzip_header = false);
 
   /// Destructor, will release z_stream.
   ~Comp();


### PR DESCRIPTION
The original implementation only supports zlib format (header and tailer). Those modifications allow 
- compressors supporting both zlib and gzip formats (using an option), 
- decompressors detecting automatically zlib/gzip format at reading.